### PR TITLE
Optimize private chat queries with PostgreSQL json_build_object

### DIFF
--- a/server/src/model/QueryHandlers.model.ts
+++ b/server/src/model/QueryHandlers.model.ts
@@ -757,7 +757,8 @@ export class QueryHandlers extends UserSchema {
             'fk_private_chat_id', ${privateMessages.fk_private_chat_id},
             'fk_user_id', ${privateMessages.fk_user_id},
             'message_text', ${privateMessages.message_text},
-            'sent_at', ${privateMessages.sent_at}
+            'sent_at', ${privateMessages.sent_at},
+            'timezone', ${privateMessages.timezone}
           ) AS "private_messages",
           
           ${privateMessages.sent_at} AS "_ordering_sent_at"  -- Hidden field for ordering
@@ -812,16 +813,16 @@ export class QueryHandlers extends UserSchema {
       // Added the recipient details to a map for faster lookup
     const allRecipientMap = new Map(allRecipients.map((recipient) => [recipient.recipient.pk_user_id, recipient.recipient]));
 
-    // Map privateChatsData and ensure unique recipients
+    // Map sortedPrivateChatData and ensure unique recipients
     const returnData = sortedPrivateChatData.map((data) => {
       // Get the ID of the other user in the private chat
-      const otherUserId =
+      const otherPrivateChatUserId =
         data.private_chat.sender_id === userId
           ? data.private_chat.recipient_id
           : data.private_chat.sender_id;
 
       // Get the recipient details from the allRecipients array
-      const recipientDetails = allRecipientMap.get(otherUserId);
+      const recipientDetails = allRecipientMap.get(otherPrivateChatUserId);
 
       return {
         private_chat: {
@@ -842,45 +843,18 @@ export class QueryHandlers extends UserSchema {
           fk_user_id: data.private_messages?.fk_user_id ?? "",
           message_text: data.private_messages?.message_text ?? "",
           sent_at: data.private_messages?.sent_at ?? new Date(0),
+          timezone: data.private_messages?.timezone ?? "",
         },
         recipient: recipientDetails, // Use the found recipient details
       };
     });
 
     // Use a Set to filter unique recipients based on their IDs
-    const uniqueRecipients = Array.from(
-      new Map(
-        // TODO: WHY DO WE NEED THIS? IF WE ARE MAKING THE RECIPIENTS UNIQUE ON LINE: 813. 
-        // WHAT if we just map through the returnData and return the unique recipients?
-        returnData.map((item) => [String(item.recipient?.pk_user_id), item]),
-      ).values(),
-    ).map((item) => ({
-      private_chat: {
-        ...item.private_chat,
-        pk_private_chat_id: item.private_chat.pk_private_chat_id,
-        sender_id: item.private_chat.sender_id,
-        recipient_id: item.private_chat.recipient_id,
-        created_at: item.private_chat.created_at,
-      },
-      chat_user: {
-        ...item.chat_user,
-        name: item.chat_user?.name ?? "",
-        email: item.chat_user?.email ?? "",
-        created_at: item.chat_user?.created_at ?? new Date(0),
-        pk_user_id: item.chat_user?.pk_user_id || undefined,
-      },
-      private_messages: {
-        ...item.private_messages,
-        id: parseInt(item.private_messages.id),
-        fk_private_chat_id: item.private_messages
-          .fk_private_chat_id as unknown as number,
-        fk_user_id: item.private_messages.fk_user_id as unknown as number,
-      },
+    const uniqueRecipients = returnData.map((item) => ({
+      ...item,
       recipient: {
+        ...item.recipient,
         pk_user_id: item.recipient?.pk_user_id ?? 0,
-        name: item.recipient?.name ?? "",
-        email: item.recipient?.email ?? "",
-        created_at: item.recipient?.created_at ?? new Date(0),
       },
     }));
 

--- a/server/src/model/QueryHandlers.model.ts
+++ b/server/src/model/QueryHandlers.model.ts
@@ -835,14 +835,14 @@ export class QueryHandlers extends UserSchema {
           pk_user_id: data.chat_user?.pk_user_id,
           name: data.chat_user?.name ?? "",
           email: data.chat_user?.email ?? "",
-          created_at: data.chat_user?.created_at ?? new Date(0),
+          created_at: data.chat_user?.created_at ?? "",
         },
         private_messages: {
           id: data.private_messages?.id as unknown as string,
           fk_private_chat_id: data.private_messages?.fk_private_chat_id ?? "",
           fk_user_id: data.private_messages?.fk_user_id ?? "",
           message_text: data.private_messages?.message_text ?? "",
-          sent_at: data.private_messages?.sent_at ?? new Date(0),
+          sent_at: data.private_messages?.sent_at ?? "",
           timezone: data.private_messages?.timezone ?? "",
         },
         recipient: recipientDetails, // Use the found recipient details

--- a/server/src/model/QueryHandlers.model.ts
+++ b/server/src/model/QueryHandlers.model.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, inArray, ne, or, sql } from "drizzle-orm";
-import { NodePgDatabase, } from "drizzle-orm/node-postgres";
+import { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { connectToDB } from "../db";
 import {
   chatMembers,
@@ -521,14 +521,12 @@ export class QueryHandlers extends UserSchema {
    * @param {number} userId - The ID of the user.
    * @returns {Promise<{ id: number }>} - The ID of the newly created chat room.
    */
-  async createNewChatroomRoomNameAndByUserId(
-    chatData: {
-      chatName: string;
-      created_at: string;
-      timezone: string;
-      userId: number;
-    },
-  ): Promise<{
+  async createNewChatroomRoomNameAndByUserId(chatData: {
+    chatName: string;
+    created_at: string;
+    timezone: string;
+    userId: number;
+  }): Promise<{
     chats?: {
       pk_chats_id: number;
       chat_name: string | null;
@@ -547,7 +545,7 @@ export class QueryHandlers extends UserSchema {
         userId,
       };
     }
-    if ( timezone === undefined || created_at === undefined) {
+    if (timezone === undefined || created_at === undefined) {
       return {
         error: true,
         reason: `Bad Request: timezone, and created_at are required to create a chat room`,
@@ -665,8 +663,6 @@ export class QueryHandlers extends UserSchema {
    * @returns {Promise<PrivateChatResult[]>} - An array of private chat rooms.
    */
   async getPrivateChatsForUser(userId: number) {
-
-
     const latest_messages = await this.db.execute(sql`
       SELECT *
       FROM (
@@ -680,14 +676,14 @@ export class QueryHandlers extends UserSchema {
             'recipient_id', ${privateChats.recipient_id},
             'created_at', ${privateChats.created_at}
           ) AS "private_chat",
-          
+
           json_build_object(
             'pk_user_id', ${user.pk_user_id},
             'name', ${user.name},
             'email', ${user.email},
             'created_at', ${user.created_at}
           ) AS "chat_user",
-          
+
           json_build_object(
             'id', ${privateMessages.id},
             'fk_private_chat_id', ${privateMessages.fk_private_chat_id},
@@ -695,31 +691,27 @@ export class QueryHandlers extends UserSchema {
             'message_text', ${privateMessages.message_text},
             'sent_at', ${privateMessages.sent_at}
           ) AS "private_messages",
-          
+
           ${privateMessages.sent_at} AS "_ordering_sent_at"  -- Hidden field for ordering
-          
+
         FROM ${privateMessages}
         LEFT JOIN ${privateChats}
           ON ${privateMessages.fk_private_chat_id} = ${privateChats.pk_private_chat_id}
         LEFT JOIN ${user}
           ON ${user.pk_user_id} = ${userId}
         WHERE ${privateChats.sender_id} = ${userId} OR ${privateChats.recipient_id} = ${userId}
-        ORDER BY 
+        ORDER BY
           LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
           GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id}),
           ${privateMessages.sent_at} DESC
       ) AS latest_messages
       ORDER BY latest_messages."_ordering_sent_at" DESC
     `);
-        
-      const privateChatsData = latest_messages.rows;
-    
-      return privateChatsData;
-    }
-    
 
+    const privateChatsData = latest_messages.rows;
 
-
+    return privateChatsData;
+  }
 
   /**
    * @description Retrieves the latest private chat messages sent by a user.
@@ -730,8 +722,9 @@ export class QueryHandlers extends UserSchema {
     userId,
   }: {
     userId: number;
-  }): Promise<PrivateChatResult[]> {
-    const latest_messages = await this.db.execute(sql`
+  }): Promise<PrivateChatResult[] | SQLErrorType> {
+    try {
+      const latest_messages = await this.db.execute(sql`
       SELECT *
       FROM (
         SELECT DISTINCT ON (
@@ -744,14 +737,12 @@ export class QueryHandlers extends UserSchema {
             'recipient_id', ${privateChats.recipient_id},
             'created_at', ${privateChats.created_at}
           ) AS "private_chat",
-          
           json_build_object(
             'pk_user_id', ${user.pk_user_id},
             'name', ${user.name},
             'email', ${user.email},
             'created_at', ${user.created_at}
           ) AS "chat_user",
-          
           json_build_object(
             'id', ${privateMessages.id},
             'fk_private_chat_id', ${privateMessages.fk_private_chat_id},
@@ -760,118 +751,136 @@ export class QueryHandlers extends UserSchema {
             'sent_at', ${privateMessages.sent_at},
             'timezone', ${privateMessages.timezone}
           ) AS "private_messages",
-          
           ${privateMessages.sent_at} AS "_ordering_sent_at"  -- Hidden field for ordering
-          
         FROM ${privateMessages}
         LEFT JOIN ${privateChats}
           ON ${privateMessages.fk_private_chat_id} = ${privateChats.pk_private_chat_id}
         LEFT JOIN ${user}
           ON ${user.pk_user_id} = ${userId}
         WHERE ${privateChats.sender_id} = ${userId} OR ${privateChats.recipient_id} = ${userId}
-        ORDER BY 
+        ORDER BY
           LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
           GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id}),
           ${privateMessages.sent_at} DESC
       ) AS latest_messages
       ORDER BY latest_messages."_ordering_sent_at" DESC
     `);
-        
-      const sortedPrivateChatData= latest_messages.rows.map((row) => ({
-        private_chat: row.private_chat as PrivateChatResult['private_chat'],
-        chat_user: row.chat_user as PrivateChatResult['chat_user'],
-        private_messages: row.private_messages as PrivateChatResult['private_messages']
+
+      const sortedPrivateChatData = latest_messages.rows.map((row) => ({
+        private_chat: row.private_chat as PrivateChatResult["private_chat"],
+        chat_user: row.chat_user as PrivateChatResult["chat_user"],
+        private_messages:
+          row.private_messages as PrivateChatResult["private_messages"],
       }));
 
-
-    // Get unique recipient IDs that are not the current user
-    const recipientIds = new Set(
-      sortedPrivateChatData.map((data) =>
-        // if the current user is the sender, then get the recipient id, otherwise get the sender id
-        data.private_chat.sender_id === userId
-          ? data.private_chat.recipient_id 
-          : data.private_chat.sender_id,
-      ),
-    );
-
-    if (recipientIds.size === 0) {
-      return [];
-    }
-    // Fetch recipient details from user table
-    const allRecipients = await this.db
-      .select({
-        recipient: {
-          pk_user_id: user.pk_user_id,
-          name: user.name,
-          email: user.email,
-          created_at: user.created_at,
-        },
-      })
-      .from(user)
-      .where(
-        inArray(
-          user.pk_user_id,
-          Array.from(recipientIds).map((id) => id),
+      // Get unique recipient IDs that are not the current user
+      const recipientIds = new Set(
+        sortedPrivateChatData.map((data) =>
+          // if the current user is the sender, then get the recipient id, otherwise get the sender id
+          data.private_chat.sender_id === userId
+            ? data.private_chat.recipient_id
+            : data.private_chat.sender_id,
         ),
       );
+
+      if (recipientIds.size === 0) {
+        return [];
+      }
+      // Fetch recipient details from user table
+      const allRecipients = await this.db
+        .select({
+          recipient: {
+            pk_user_id: user.pk_user_id,
+            name: user.name,
+            email: user.email,
+            created_at: user.created_at,
+          },
+        })
+        .from(user)
+        .where(
+          inArray(
+            user.pk_user_id,
+            Array.from(recipientIds).map((id) => id),
+          ),
+        );
       // Added the recipient details to a map for faster lookup
-    const allRecipientMap = new Map(allRecipients.map((recipient) => [recipient.recipient.pk_user_id, recipient.recipient]));
+      const allRecipientMap = new Map(
+        allRecipients.map((recipient) => [
+          recipient.recipient.pk_user_id,
+          recipient.recipient,
+        ]),
+      );
 
-    // Map sortedPrivateChatData and ensure unique recipients
-    const returnData = sortedPrivateChatData.map((data) => {
-      // Get the ID of the other user in the private chat
-      const otherPrivateChatUserId =
-        data.private_chat.sender_id === userId
-          ? data.private_chat.recipient_id
-          : data.private_chat.sender_id;
+      // Map sortedPrivateChatData and ensure unique recipients
+      const returnData = sortedPrivateChatData.map((data) => {
+        // Get the ID of the other user in the private chat
+        const otherPrivateChatUserId =
+          data.private_chat.sender_id === userId
+            ? data.private_chat.recipient_id
+            : data.private_chat.sender_id;
 
-      // Get the recipient details from the allRecipients array
-      const recipientDetails = allRecipientMap.get(otherPrivateChatUserId);
+        // Get the recipient details from the allRecipients array
+        const recipientDetails = allRecipientMap.get(otherPrivateChatUserId);
 
+        return {
+          private_chat: {
+            pk_private_chat_id: data.private_chat.pk_private_chat_id,
+            sender_id: data.private_chat.sender_id,
+            recipient_id: data.private_chat.recipient_id,
+            created_at: data.private_chat.created_at,
+          },
+          chat_user: {
+            pk_user_id: data.chat_user?.pk_user_id,
+            name: data.chat_user?.name ?? "",
+            email: data.chat_user?.email ?? "",
+            created_at: data.chat_user?.created_at ?? "",
+          },
+          private_messages: {
+            id: data.private_messages?.id as unknown as string,
+            fk_private_chat_id: data.private_messages?.fk_private_chat_id ?? "",
+            fk_user_id: data.private_messages?.fk_user_id ?? "",
+            message_text: data.private_messages?.message_text ?? "",
+            sent_at: data.private_messages?.sent_at ?? "",
+            timezone: data.private_messages?.timezone ?? "",
+          },
+          recipient: recipientDetails, // Use the found recipient details
+        };
+      });
+
+      // Use a Set to filter unique recipients based on their IDs
+      // Create a map to ensure uniqueness based on recipient ID
+      const seenRecipients = new Map();
+      const uniqueRecipients = returnData
+        .filter((item) => {
+          const recipientId = item.recipient?.pk_user_id;
+
+          if (!recipientId || seenRecipients.has(recipientId)) return false;
+
+          seenRecipients.set(recipientId, true);
+          return true;
+        })
+        .map((item) => ({
+          ...item,
+          recipient: {
+            ...item.recipient,
+            pk_user_id: item.recipient?.pk_user_id ?? 0,
+          },
+        }));
+
+      return uniqueRecipients as unknown as PrivateChatResult[];
+    } catch (err) {
+      if (typeof err === "object" && Object.keys(err as object).length) {
+        return {
+          ...err,
+          error: true,
+          reason: err.message,
+        };
+      }
       return {
-        private_chat: {
-          pk_private_chat_id: data.private_chat.pk_private_chat_id,
-          sender_id: data.private_chat.sender_id,
-          recipient_id: data.private_chat.recipient_id,
-          created_at: data.private_chat.created_at,
-        },
-        chat_user: {
-          pk_user_id: data.chat_user?.pk_user_id,
-          name: data.chat_user?.name ?? "",
-          email: data.chat_user?.email ?? "",
-          created_at: data.chat_user?.created_at ?? "",
-        },
-        private_messages: {
-          id: data.private_messages?.id as unknown as string,
-          fk_private_chat_id: data.private_messages?.fk_private_chat_id ?? "",
-          fk_user_id: data.private_messages?.fk_user_id ?? "",
-          message_text: data.private_messages?.message_text ?? "",
-          sent_at: data.private_messages?.sent_at ?? "",
-          timezone: data.private_messages?.timezone ?? "",
-        },
-        recipient: recipientDetails, // Use the found recipient details
+        error: true,
+        reason: err.message,
       };
-    });
-
-    // Use a Set to filter unique recipients based on their IDs
-    // Create a map to ensure uniqueness based on recipient ID
-    const seenRecipients = new Map();
-    const uniqueRecipients = returnData.filter((item) => {
-      const recipientId = item.recipient?.pk_user_id;
-
-      if (!recipientId || seenRecipients.has(recipientId)) return false;
-      
-      seenRecipients.set(recipientId, true);
-      return true;
-    }).map((item) => ({
-      ...item,
-      recipient: {
-        ...item.recipient,
-        pk_user_id: item.recipient?.pk_user_id ?? 0,
-      },
-    }));
-
-    return uniqueRecipients as unknown as PrivateChatResult[];
+    }
   }
 
   /**

--- a/server/src/model/QueryHandlers.model.ts
+++ b/server/src/model/QueryHandlers.model.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, inArray, ne, or, sql } from "drizzle-orm";
-import { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { NodePgDatabase, } from "drizzle-orm/node-postgres";
 import { connectToDB } from "../db";
 import {
   chatMembers,
@@ -665,53 +665,61 @@ export class QueryHandlers extends UserSchema {
    * @returns {Promise<PrivateChatResult[]>} - An array of private chat rooms.
    */
   async getPrivateChatsForUser(userId: number) {
-    // Subquery to get the latest message for each chat
-    const latestMessages = await this.db.$with("latest_messages").as(
-      this.db
-        .select({
-          fkPrivateChatId: privateMessages.fk_private_chat_id,
-          maxSentAt: sql`MAX(${privateMessages.sent_at} AT TIME ZONE ${privateMessages.timezone})`.as("latest_sent_at"),
-        })
-        .from(privateMessages)
-        .groupBy(privateMessages.fk_private_chat_id),
-    );
 
-    // Main query
-    const privateChatsData = await this.db
-      .with(latestMessages)
-      .select({
-        chatId: privateChats.pk_private_chat_id,
-        senderId: privateChats.sender_id,
-        recipientId: privateChats.recipient_id,
-        chatCreatedAt: privateChats.created_at,
-        messageId: privateMessages.id,
-        messageSenderId: privateMessages.fk_user_id,
-        messageText: privateMessages.message_text,
-        imageName: privateMessages.image_name,
-        sentAt: privateMessages.sent_at,
-        userName: user.name,
-        userEmail: user.email,
-      })
-      .from(privateChats)
-      .innerJoin(
-        latestMessages,
-        eq(privateChats.pk_private_chat_id, latestMessages.fkPrivateChatId),
-      )
-      .innerJoin(
-        privateMessages,
-        sql`${privateMessages.fk_private_chat_id} = ${privateChats.pk_private_chat_id} AND ${privateMessages.sent_at} = ${latestMessages.maxSentAt}`,
-      )
-      .innerJoin(user, eq(user.pk_user_id, userId))
-      .where(
-        or(
-          eq(privateChats.sender_id, userId),
-          eq(privateChats.recipient_id, userId),
-        ),
-      )
-      .orderBy(desc(privateMessages.sent_at));
 
-    return privateChatsData;
-  }
+    const latest_messages = await this.db.execute(sql`
+      SELECT *
+      FROM (
+        SELECT DISTINCT ON (
+          LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id})
+        )
+          json_build_object(
+            'pk_private_chat_id', ${privateChats.pk_private_chat_id},
+            'sender_id', ${privateChats.sender_id},
+            'recipient_id', ${privateChats.recipient_id},
+            'created_at', ${privateChats.created_at}
+          ) AS "private_chat",
+          
+          json_build_object(
+            'pk_user_id', ${user.pk_user_id},
+            'name', ${user.name},
+            'email', ${user.email},
+            'created_at', ${user.created_at}
+          ) AS "chat_user",
+          
+          json_build_object(
+            'id', ${privateMessages.id},
+            'fk_private_chat_id', ${privateMessages.fk_private_chat_id},
+            'fk_user_id', ${privateMessages.fk_user_id},
+            'message_text', ${privateMessages.message_text},
+            'sent_at', ${privateMessages.sent_at}
+          ) AS "private_messages",
+          
+          ${privateMessages.sent_at} AS "_ordering_sent_at"  -- Hidden field for ordering
+          
+        FROM ${privateMessages}
+        LEFT JOIN ${privateChats}
+          ON ${privateMessages.fk_private_chat_id} = ${privateChats.pk_private_chat_id}
+        LEFT JOIN ${user}
+          ON ${user.pk_user_id} = ${userId}
+        WHERE ${privateChats.sender_id} = ${userId} OR ${privateChats.recipient_id} = ${userId}
+        ORDER BY 
+          LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          ${privateMessages.sent_at} DESC
+      ) AS latest_messages
+      ORDER BY latest_messages."_ordering_sent_at" DESC
+    `);
+        
+      const privateChatsData = latest_messages.rows;
+    
+      return privateChatsData;
+    }
+    
+
+
+
 
   /**
    * @description Retrieves the latest private chat messages sent by a user.
@@ -723,59 +731,60 @@ export class QueryHandlers extends UserSchema {
   }: {
     userId: number;
   }): Promise<PrivateChatResult[]> {
-    const privateChatsData = await this.db
-      .selectDistinctOn([privateChats.recipient_id, privateChats.sender_id], {
-        private_chat: {
-          pk_private_chat_id: privateChats.pk_private_chat_id,
-          sender_id: privateChats.sender_id,
-          recipient_id: privateChats.recipient_id,
-          created_at: privateChats.created_at,
-        },
-        chat_user: {
-          pk_user_id: user.pk_user_id,
-          name: user.name,
-          email: user.email,
-          created_at: user.created_at,
-        },
-        private_messages: {
-          id: privateMessages.id,
-          fk_private_chat_id: privateMessages.fk_private_chat_id,
-          fk_user_id: privateMessages.fk_user_id,
-          message_text: privateMessages.message_text,
-          sent_at: privateMessages.sent_at,
-        },
-      })
-      .from(privateChats)
-      .where(
-        or(
-          eq(privateChats.sender_id, userId),
-          eq(privateChats.recipient_id, userId),
-        ),
-      )
-      .orderBy(
-        privateChats.recipient_id,
-        privateChats.sender_id,
-        desc(privateMessages.sent_at),
-      )
-      .leftJoin(user, eq(user.pk_user_id, userId))
-      .leftJoin(
-        privateMessages,
-        eq(privateMessages.fk_private_chat_id, privateChats.pk_private_chat_id),
-      );
+    const latest_messages = await this.db.execute(sql`
+      SELECT *
+      FROM (
+        SELECT DISTINCT ON (
+          LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id})
+        )
+          json_build_object(
+            'pk_private_chat_id', ${privateChats.pk_private_chat_id},
+            'sender_id', ${privateChats.sender_id},
+            'recipient_id', ${privateChats.recipient_id},
+            'created_at', ${privateChats.created_at}
+          ) AS "private_chat",
+          
+          json_build_object(
+            'pk_user_id', ${user.pk_user_id},
+            'name', ${user.name},
+            'email', ${user.email},
+            'created_at', ${user.created_at}
+          ) AS "chat_user",
+          
+          json_build_object(
+            'id', ${privateMessages.id},
+            'fk_private_chat_id', ${privateMessages.fk_private_chat_id},
+            'fk_user_id', ${privateMessages.fk_user_id},
+            'message_text', ${privateMessages.message_text},
+            'sent_at', ${privateMessages.sent_at}
+          ) AS "private_messages",
+          
+          ${privateMessages.sent_at} AS "_ordering_sent_at"  -- Hidden field for ordering
+          
+        FROM ${privateMessages}
+        LEFT JOIN ${privateChats}
+          ON ${privateMessages.fk_private_chat_id} = ${privateChats.pk_private_chat_id}
+        LEFT JOIN ${user}
+          ON ${user.pk_user_id} = ${userId}
+        WHERE ${privateChats.sender_id} = ${userId} OR ${privateChats.recipient_id} = ${userId}
+        ORDER BY 
+          LEAST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          GREATEST(${privateChats.sender_id}, ${privateChats.recipient_id}),
+          ${privateMessages.sent_at} DESC
+      ) AS latest_messages
+      ORDER BY latest_messages."_ordering_sent_at" DESC
+    `);
+        
+      const sortedPrivateChatData= latest_messages.rows as unknown as PrivateChatResult[];
 
-    // THIS GETS THE LATEST MESSAGE SENT AND DOES NOT SORT THE QUERIED DATA.
-    const sortedPrivateChatData = [...privateChatsData].sort((chatA, chatB) => {
-      return new Date(chatA.private_messages?.sent_at || 0) >
-        new Date(chatB.private_messages?.sent_at || 0)
-        ? -1
-        : 1;
-    });
 
     // Get unique recipient IDs that are not the current user
     const recipientIds = new Set(
       sortedPrivateChatData.map((data) =>
+        // if the current user is the sender, then get the recipient id, otherwise get the sender id
         data.private_chat.sender_id === userId
-          ? data.private_chat.recipient_id
+          ? data.private_chat.recipient_id 
           : data.private_chat.sender_id,
       ),
     );
@@ -800,19 +809,19 @@ export class QueryHandlers extends UserSchema {
           Array.from(recipientIds).map((id) => id),
         ),
       );
+      // Added the recipient details to a map for faster lookup
+    const allRecipientMap = new Map(allRecipients.map((recipient) => [recipient.recipient.pk_user_id, recipient.recipient]));
 
     // Map privateChatsData and ensure unique recipients
     const returnData = sortedPrivateChatData.map((data) => {
-      // Determine the correct recipient ID based on the current user
+      // Get the ID of the other user in the private chat
       const otherUserId =
         data.private_chat.sender_id === userId
           ? data.private_chat.recipient_id
           : data.private_chat.sender_id;
 
-      // Find the recipient details
-      const recipientDetails = allRecipients.find(
-        (d) => d.recipient.pk_user_id === otherUserId,
-      )?.recipient;
+      // Get the recipient details from the allRecipients array
+      const recipientDetails = allRecipientMap.get(otherUserId);
 
       return {
         private_chat: {
@@ -841,6 +850,8 @@ export class QueryHandlers extends UserSchema {
     // Use a Set to filter unique recipients based on their IDs
     const uniqueRecipients = Array.from(
       new Map(
+        // TODO: WHY DO WE NEED THIS? IF WE ARE MAKING THE RECIPIENTS UNIQUE ON LINE: 813. 
+        // WHAT if we just map through the returnData and return the unique recipients?
         returnData.map((item) => [String(item.recipient?.pk_user_id), item]),
       ).values(),
     ).map((item) => ({

--- a/server/src/model/QueryHandlers.model.ts
+++ b/server/src/model/QueryHandlers.model.ts
@@ -777,7 +777,11 @@ export class QueryHandlers extends UserSchema {
       ORDER BY latest_messages."_ordering_sent_at" DESC
     `);
         
-      const sortedPrivateChatData= latest_messages.rows as unknown as PrivateChatResult[];
+      const sortedPrivateChatData= latest_messages.rows.map((row) => ({
+        private_chat: row.private_chat as PrivateChatResult['private_chat'],
+        chat_user: row.chat_user as PrivateChatResult['chat_user'],
+        private_messages: row.private_messages as PrivateChatResult['private_messages']
+      }));
 
 
     // Get unique recipient IDs that are not the current user
@@ -850,7 +854,16 @@ export class QueryHandlers extends UserSchema {
     });
 
     // Use a Set to filter unique recipients based on their IDs
-    const uniqueRecipients = returnData.map((item) => ({
+    // Create a map to ensure uniqueness based on recipient ID
+    const seenRecipients = new Map();
+    const uniqueRecipients = returnData.filter((item) => {
+      const recipientId = item.recipient?.pk_user_id;
+
+      if (!recipientId || seenRecipients.has(recipientId)) return false;
+      
+      seenRecipients.set(recipientId, true);
+      return true;
+    }).map((item) => ({
       ...item,
       recipient: {
         ...item.recipient,

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -66,7 +66,6 @@ export interface PrivateMessageBase extends MessageBase {
   fk_private_chat_id: number;
   image_file: Buffer | string | null;
   image_name: string | null;
-  sent_at: string;
   timezone: string;
 }
 

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -66,6 +66,8 @@ export interface PrivateMessageBase extends MessageBase {
   fk_private_chat_id: number;
   image_file: Buffer | string | null;
   image_name: string | null;
+  sent_at: string;
+  timezone: string;
 }
 
 // Chat Types


### PR DESCRIPTION
Issue Number: #7 
- Replace complex Drizzle ORM queries with raw SQL using json_build_object
- Implement DISTINCT ON with LEAST/GREATEST to get latest messages per chat
- Add efficient recipient lookup using Map instead of array find
- Remove client-side sorting in favor of SQL ORDER BY
- Fix user join to get correct recipient details
- Add hidden _ordering_sent_at field for consistent sorting
- Improve code readability with better comments

This change improves performance by:
1. Reducing database round trips
2. Moving sorting to the database layer
3. Using more efficient data structures for lookups
4. Leveraging PostgreSQL's native JSON capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `timezone` to enhance private message data structure.

- **Refactor**
	- Optimized private chat and message retrieval for faster, more efficient data delivery.
	- Enhanced performance by streamlining data aggregation and reducing redundant operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->