### PR TITLE
Fix sidebar user list sync

### DIFF
--- a/client/src/components/layout/chat-room/private-chat-section.tsx
+++ b/client/src/components/layout/chat-room/private-chat-section.tsx
@@ -9,7 +9,6 @@ import useAuthStorage from "../../../store/useAuthStorage";
 import { PrivateChatResultType } from "../../../types";
 import { Card, CardContent } from "../../ui/card";
 import { ScrollArea } from "../../ui/scroll-area";
-import { isPrivateChatBetweenTwoUsers } from "../../../hooks/useGetPrivateMessageList";
 
 export default function ImageCard({
 	imageUrl,
@@ -104,29 +103,33 @@ export const PrivateMessageSection = ({ data }: { data: PrivateChatResultType[] 
 
 	useEffect(() => {
 		if (socket?.connected === false) socket?.connect();
+		if (!userId) return; // Maybe logout?
 
 		socket?.on("add-private-message-response", (response: PrivateChatResultType) => {
 			const { sender_id: responseSenderId, recipient_id: responseRecipientId } =
 				response.private_chat;
 
+			const chatUser = new Set([responseSenderId, responseRecipientId]);
+
 			// IF users are not the same, return early
-			if (
-				!isPrivateChatBetweenTwoUsers({
-					responseSenderId,
-					responseRecipientId,
-					userId,
-					recipientId,
-				})
-			) {
+			if (!chatUser.has(userId)) {
 				return;
 			}
+			// Prevent messages from showing in other users chats
+			const chatToUpdate =
+				(responseSenderId.toString() === userId.toString() &&
+					responseRecipientId.toString() === recipientId?.toString()) ||
+				(responseSenderId.toString() === recipientId?.toString() &&
+					responseRecipientId.toString() === userId.toString());
+
+			if (chatToUpdate === false) return;
 
 			setAllRoomMessages((previousRoomMessages) => {
 				const responseCopy = { ...response };
 				if (String(response.chat_user.pk_user_id) === String(userId)) {
 					set(responseCopy, "chat_user.name", "You");
 				}
-				return previousRoomMessages.concat(responseCopy);
+				return [...previousRoomMessages, responseCopy];
 			});
 
 			if (vListRef.current) {

--- a/client/src/hooks/useGetPrivateMessageList.tsx
+++ b/client/src/hooks/useGetPrivateMessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useNavigate } from "react-router-dom";
 import { PrivateChatResultType } from "./../types/index";
@@ -6,31 +6,32 @@ import { PrivateChatResultType } from "./../types/index";
 import { Socket } from "socket.io-client";
 import useAuthStorage from "../store/useAuthStorage";
 
-// Create a utility function for checking chat participants
+/**
+ * Checks if the user is a participant in the chat
+ * @param userId - The user's ID
+ * @param chatUsers - An array of user IDs that are part of the chat
+ * @returns true if the user is a participant in the chat, false otherwise
+ */
 const isChatParticipant = (userId: string, chatUsers: string[]) => {
 	const chatUserSet = new Set(chatUsers);
 	return chatUserSet.has(userId);
 };
 
-export function isPrivateChatBetweenTwoUsers({
-	responseRecipientId,
-	responseSenderId,
-	userId,
-	recipientId,
-}: {
-	responseRecipientId: string | null;
-	responseSenderId: string | null;
-	userId: string | null;
-	recipientId?: string;
-}): boolean {
-	const senderIdString = String(responseSenderId);
-	const recipientIdString = String(responseRecipientId);
-	const userIdString = String(userId);
+/**
+ * Checks if two chats are the same
+ * @param chat1 - The first chat
+ * @param chat2 - The second chat
+ * @returns true if the chats are the same, false otherwise
+ */
+const doChatsMatch = (
+	chat1: { sender_id: string; recipient_id: string },
+	chat2: { sender_id: string; recipient_id: string }
+) => {
 	return (
-		(senderIdString === userIdString && recipientIdString === recipientId) ||
-		(senderIdString === recipientId && recipientIdString === userIdString)
+		(chat1.sender_id === chat2.sender_id && chat1.recipient_id === chat2.recipient_id) ||
+		(chat1.sender_id === chat2.recipient_id && chat1.recipient_id === chat2.sender_id)
 	);
-}
+};
 
 function updateChatList({
 	state,
@@ -46,11 +47,11 @@ function updateChatList({
 		stateSenderId = state.private_chat.sender_id,
 		stateRecipientId = state.private_chat.recipient_id;
 
+	const isChatUser = isChatParticipant(userId, [stateSenderId, stateRecipientId]);
+
 	const chatToUpdate =
 		(responseSenderId === stateSenderId && responseRecipientId === stateRecipientId) ||
 		(responseSenderId === stateRecipientId && responseRecipientId === stateSenderId);
-
-	const isChatUser = isChatParticipant(userId, [stateSenderId, stateRecipientId]);
 
 	if (isChatUser && chatToUpdate) {
 		// This Updates the most recent message sent
@@ -72,75 +73,41 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 	const navigate = useNavigate();
 	const { userId } = useAuthStorage((state) => state);
 
-	const handleMessageUpdate = (response: PrivateChatResultType) => {
-		const { sender_id: responseSenderId, recipient_id: responseRecipientId } =
-			response.private_chat;
-		const privateMessageUserIds = [responseSenderId, responseRecipientId];
-		if (!userId) return;
-		// If we're in a specific chat, only update that chat
+	const handleMessageUpdate = useCallback(
+		(response: PrivateChatResultType) => {
+			if (!userId) return;
 
-		if (!isChatParticipant(userId, privateMessageUserIds)) {
-			return;
-		}
+			const { sender_id: responseSenderId, recipient_id: responseRecipientId } =
+				response.private_chat;
+			const privateMessageUserIds = [responseSenderId, responseRecipientId];
 
-		setPrivateRoomList((prevList) => {
-			const userExist = prevList.some((chat) => {
-				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
-					chat.private_chat;
-				const chatUserIds = [chatSenderId, chatRecipientId];
-
-				const recipientExist = isChatParticipant(responseRecipientId, chatUserIds);
-				const senderExist = isChatParticipant(responseSenderId, chatUserIds);
-
-				return recipientExist && senderExist;
-			});
-
-			if (userExist === false) {
-				return [
-					updateChatList({
-						userId,
-						response,
-						state: response,
-					}),
-					...prevList,
-				];
+			// Check if the user is a participant in the chat If not, return early
+			if (!isChatParticipant(userId, privateMessageUserIds)) {
+				return;
 			}
-			// Check if this chat already exists
-			const existingChatIndex = prevList.filter((chat) => {
-				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
-					chat.private_chat;
-				// IF the current user if not part of a chat, return early.
-				return isChatParticipant(userId, [chatSenderId, chatRecipientId]);
-			});
 
-			if (existingChatIndex.length === 0) {
-				// This is a new chat, add it to the list
-				return [
-					updateChatList({
-						userId,
-						response,
-						state: response,
-					}),
-				];
-			}
-			// Update existing chat
-			const filteredList = prevList.filter((chat) => {
-				const { sender_id, recipient_id } = chat.private_chat;
-				const chatToFilterOut =
-					(sender_id === responseSenderId && recipient_id === responseRecipientId) ||
-					(sender_id === responseRecipientId && recipient_id === responseSenderId);
-				return chatToFilterOut === false;
+			setPrivateRoomList((prevList) => {
+				// Check if the new response is part of a message sent by an already existing chat.
+				const userExist = prevList.some((chat) =>
+					doChatsMatch(chat.private_chat, response.private_chat)
+				);
+
+				// If the user does not exist, update the chat list with the new message
+				if (userExist === false) {
+					return [updateChatList({ userId, response, state: response }), ...prevList];
+				}
+
+				//Filter out the chat that has the same sender and recipient from the list. This is the response that we want to update.
+				const updatedList = prevList.filter(
+					(chat) => !doChatsMatch(chat.private_chat, response.private_chat)
+				);
+
+				// Update the chat list with the new message
+				return [updateChatList({ userId, response, state: response }), ...updatedList];
 			});
-			return [
-				updateChatList({
-					userId,
-					response,
-					state: response,
-				}),
-				...filteredList,
-			];
-		});
-	};
+		},
+		[userId]
+	);
 
 	useEffect(() => {
 		if (socket === null) return;

--- a/client/src/hooks/useGetPrivateMessageList.tsx
+++ b/client/src/hooks/useGetPrivateMessageList.tsx
@@ -20,7 +20,6 @@ export function isPrivateChatBetweenTwoUsers({
 	const senderIdString = String(responseSenderId);
 	const recipientIdString = String(responseRecipientId);
 	const userIdString = String(userId);
-
 	return (
 		(senderIdString === userIdString && recipientIdString === recipientId) ||
 		(senderIdString === recipientId && recipientIdString === userIdString)
@@ -31,25 +30,22 @@ function updateChatList({
 	state,
 	response,
 	userId,
-	recipientId,
 }: {
+	userId: string;
 	state: PrivateChatResultType;
 	response: PrivateChatResultType;
-	userId: string;
-	recipientId?: string;
 }) {
-	if (!recipientId) return state;
+	const chatUser = new Set([state.private_chat.sender_id, state.private_chat.recipient_id]);
+	const responseSenderId = response.private_chat.sender_id,
+		responseRecipientId = response.private_chat.recipient_id,
+		stateSenderId = state.private_chat.sender_id,
+		stateRecipientId = state.private_chat.recipient_id;
 
-	const { sender_id, recipient_id } = state.private_chat;
+	const chatToUpdate =
+		(responseSenderId === stateSenderId && responseRecipientId === stateRecipientId) ||
+		(responseSenderId === stateRecipientId && responseRecipientId === stateSenderId);
 
-	if (
-		isPrivateChatBetweenTwoUsers({
-			responseSenderId: String(sender_id),
-			responseRecipientId: String(recipient_id),
-			userId: String(userId),
-			recipientId: String(recipientId),
-		})
-	) {
+	if (chatUser.has(userId) && chatToUpdate) {
 		// This Updates the most recent message sent
 		return {
 			...state, // Create a new object
@@ -68,52 +64,79 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 	const [privateRoomList, setPrivateRoomList] = useState<PrivateChatResultType[]>([]);
 	const navigate = useNavigate();
 	const { userId } = useAuthStorage((state) => state);
-	const { recipientId } = useParams();
+	const { recipientId } = useParams(); // This should not be from params.
 
 	const handleMessageUpdate = (response: PrivateChatResultType) => {
 		const { sender_id: responseSenderId, recipient_id: responseRecipientId } =
 			response.private_chat;
-
+		const chatUser = new Set([responseSenderId, responseRecipientId]);
+		if (!userId) return;
 		// If we're in a specific chat, only update that chat
-		if (recipientId) {
-			const isSameChat = isPrivateChatBetweenTwoUsers({
-				responseSenderId,
-				responseRecipientId,
-				userId,
-				recipientId,
-			});
 
-			if (!isSameChat) {
+		if (recipientId) {
+			// TODO: WHYYYYY
+			if (!chatUser.has(userId)) {
 				return;
 			}
 		}
 
-		if (!userId) return;
-
 		setPrivateRoomList((prevList) => {
+			const userExist = prevList.some((chat) => {
+				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
+					chat.private_chat;
+				const chatIdBetweenUsers = new Set([chatSenderId, chatRecipientId]);
+
+				const recipientExist = chatIdBetweenUsers.has(response.private_chat.recipient_id);
+				const senderExist = chatIdBetweenUsers.has(response.private_chat.sender_id);
+
+				return recipientExist && senderExist;
+			});
+
+			if (userExist === false) {
+				return [
+					updateChatList({
+						userId,
+						response,
+						state: response,
+					}),
+					...prevList,
+				];
+			}
 			// Check if this chat already exists
 			const existingChatIndex = prevList.filter((chat) => {
-				const { sender_id: charSenderId, recipient_id: chatRecipientId } =
+				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
 					chat.private_chat;
-
-				const isSameChat = isPrivateChatBetweenTwoUsers({
-					responseSenderId: String(charSenderId),
-					responseRecipientId: String(chatRecipientId),
-					userId: String(userId),
-					recipientId: String(recipientId),
-				});
-				return !isSameChat;
+				const existingChatUser = new Set([chatSenderId, chatRecipientId]);
+				// IF the current user if not part of a chat, return early.
+				return existingChatUser.has(userId);
 			});
 
 			if (existingChatIndex.length === 0) {
 				// This is a new chat, add it to the list
-				return [updateChatList({ state: response, response, userId, recipientId })];
+				return [
+					updateChatList({
+						userId,
+						response,
+						state: response,
+					}),
+				];
 			}
-
 			// Update existing chat
-			return prevList.map((chat) =>
-				updateChatList({ state: chat, response, userId, recipientId })
-			);
+			const filteredList = prevList.filter((chat) => {
+				const { sender_id, recipient_id } = chat.private_chat;
+				const chatToFilterOut =
+					(sender_id === responseSenderId && recipient_id === responseRecipientId) ||
+					(sender_id === responseRecipientId && recipient_id === responseSenderId);
+				return chatToFilterOut === false;
+			});
+			return [
+				updateChatList({
+					userId,
+					response,
+					state: response,
+				}),
+				...filteredList,
+			];
 		});
 	};
 

--- a/client/src/hooks/useGetPrivateMessageList.tsx
+++ b/client/src/hooks/useGetPrivateMessageList.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { useNavigate } from "react-router-dom";
 import { PrivateChatResultType } from "./../types/index";
 
 import { Socket } from "socket.io-client";
@@ -70,7 +69,6 @@ function updateChatList({
 
 export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) => {
 	const [privateRoomList, setPrivateRoomList] = useState<PrivateChatResultType[]>([]);
-	const navigate = useNavigate();
 	const { userId } = useAuthStorage((state) => state);
 
 	const handleMessageUpdate = useCallback(
@@ -126,7 +124,7 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 			socket.off("get-latest-private-message-sent", handleMessageUpdate);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [socket, userId, navigate]);
+	}, [socket, userId]);
 
 	return {
 		privateRoomList,

--- a/client/src/hooks/useGetPrivateMessageList.tsx
+++ b/client/src/hooks/useGetPrivateMessageList.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from "react";
 
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { PrivateChatResultType } from "./../types/index";
 
 import { Socket } from "socket.io-client";
 import useAuthStorage from "../store/useAuthStorage";
+
+// Create a utility function for checking chat participants
+const isChatParticipant = (userId: string, chatUsers: string[]) => {
+	const chatUserSet = new Set(chatUsers);
+	return chatUserSet.has(userId);
+};
 
 export function isPrivateChatBetweenTwoUsers({
 	responseRecipientId,
@@ -35,7 +41,6 @@ function updateChatList({
 	state: PrivateChatResultType;
 	response: PrivateChatResultType;
 }) {
-	const chatUser = new Set([state.private_chat.sender_id, state.private_chat.recipient_id]);
 	const responseSenderId = response.private_chat.sender_id,
 		responseRecipientId = response.private_chat.recipient_id,
 		stateSenderId = state.private_chat.sender_id,
@@ -45,7 +50,9 @@ function updateChatList({
 		(responseSenderId === stateSenderId && responseRecipientId === stateRecipientId) ||
 		(responseSenderId === stateRecipientId && responseRecipientId === stateSenderId);
 
-	if (chatUser.has(userId) && chatToUpdate) {
+	const isChatUser = isChatParticipant(userId, [stateSenderId, stateRecipientId]);
+
+	if (isChatUser && chatToUpdate) {
 		// This Updates the most recent message sent
 		return {
 			...state, // Create a new object
@@ -64,30 +71,26 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 	const [privateRoomList, setPrivateRoomList] = useState<PrivateChatResultType[]>([]);
 	const navigate = useNavigate();
 	const { userId } = useAuthStorage((state) => state);
-	const { recipientId } = useParams(); // This should not be from params.
 
 	const handleMessageUpdate = (response: PrivateChatResultType) => {
 		const { sender_id: responseSenderId, recipient_id: responseRecipientId } =
 			response.private_chat;
-		const chatUser = new Set([responseSenderId, responseRecipientId]);
+		const privateMessageUserIds = [responseSenderId, responseRecipientId];
 		if (!userId) return;
 		// If we're in a specific chat, only update that chat
 
-		if (recipientId) {
-			// TODO: WHYYYYY
-			if (!chatUser.has(userId)) {
-				return;
-			}
+		if (!isChatParticipant(userId, privateMessageUserIds)) {
+			return;
 		}
 
 		setPrivateRoomList((prevList) => {
 			const userExist = prevList.some((chat) => {
 				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
 					chat.private_chat;
-				const chatIdBetweenUsers = new Set([chatSenderId, chatRecipientId]);
+				const chatUserIds = [chatSenderId, chatRecipientId];
 
-				const recipientExist = chatIdBetweenUsers.has(response.private_chat.recipient_id);
-				const senderExist = chatIdBetweenUsers.has(response.private_chat.sender_id);
+				const recipientExist = isChatParticipant(responseRecipientId, chatUserIds);
+				const senderExist = isChatParticipant(responseSenderId, chatUserIds);
 
 				return recipientExist && senderExist;
 			});
@@ -106,9 +109,8 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 			const existingChatIndex = prevList.filter((chat) => {
 				const { sender_id: chatSenderId, recipient_id: chatRecipientId } =
 					chat.private_chat;
-				const existingChatUser = new Set([chatSenderId, chatRecipientId]);
 				// IF the current user if not part of a chat, return early.
-				return existingChatUser.has(userId);
+				return isChatParticipant(userId, [chatSenderId, chatRecipientId]);
 			});
 
 			if (existingChatIndex.length === 0) {
@@ -157,7 +159,7 @@ export const useGetPrivateMessageList = ({ socket }: { socket: Socket | null }) 
 			socket.off("get-latest-private-message-sent", handleMessageUpdate);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [socket, userId, recipientId, navigate]);
+	}, [socket, userId, navigate]);
 
 	return {
 		privateRoomList,


### PR DESCRIPTION
# PR Description: Update Private Chat Section Logic

## Summary
This pull request refines the logic around private chat message handling in the `PrivateMessageSection` component. The changes improve message filtering and ensure messages are only displayed in the appropriate user chats.

## Changes Made
1. **Removed Unused Import:**
   - Removed the `isPrivateChatBetweenTwoUsers` import from `private-chat-section.tsx` as it is no longer used.

2. **Updated Socket Event Listener Logic:**
   - Added a check to ensure `userId` is defined before proceeding with the socket event listener.
   - Replaced the `isPrivateChatBetweenTwoUsers` function with a more direct approach utilizing a `Set` to verify the user IDs involved in the private chat.
   - Guarded against showing messages in unrelated user chats by adding a precise condition (`chatToUpdate`) for updating the chat list.

3. **Improved State Updates:**
   - Updated the logic for appending new messages to the `setAllRoomMessages` function by using the spread operator (`[...]`) for better readability.

4. **Code Comments:**
   - Added inline comments to clarify the purpose of the new logic and conditions applied.

## Why These Changes Are Necessary
- Prevents messages from appearing in unrelated private chats.
- Simplifies and improves the clarity of the codebase by removing unnecessary dependencies and using a direct approach for user validation.
- Enhances code maintainability and readability.

## Testing
- Verified that messages are only displayed for the intended sender and recipient.
- Confirmed that the functionality works as expected across different user sessions.
- Ensured no regression occurred by running unit tests and reviewing socket event handling.

---

Let me know if you need further clarification or additional details!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering of incoming private messages to ensure only relevant chats are updated, preventing cross-chat message leakage.
  - Fixed issues where private messages could appear in the wrong chat or update unrelated conversations.

- **Refactor**
  - Streamlined private chat message handling for better accuracy and clarity in updating the chat list.
  - Enhanced logic to always display the most recent private message at the top of the chat list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->