### PR TITLE
Refactor: Consolidate Message Rendering with `MessageCard` Component

### DIFF
--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -9,7 +9,7 @@ import type {
 } from '../pages/authentication/validation';
 
 export type ChatUserType = {
-  name: string | null;
+  name: string;
   pk_user_id: string;
   email: string | null;
   sender?: string;
@@ -46,7 +46,7 @@ export type PrivateMessageType = {
   fk_private_chat_id: string;
   fk_user_id: string;
   message_text: string;
-  sent_at: Date; // Assuming it's a timestamp
+  sent_at: string; // Assuming it's a timestamp
   image_file?: string;
   image_url?: string;
   image_name?: string;
@@ -77,7 +77,7 @@ export type MessageType = {
   fk_chat_id: string;
   fk_user_id: string;
   message_text: string | null;
-  sent_at: Date;
+  sent_at: string;
   timezone: string;
   image_file?: string;
   image_url?: string;


### PR DESCRIPTION
## Overview

This PR refactors the chat message rendering logic in both the **Channel Room** and **Private Chat** sections to use a unified `MessageCard` component. The goal is to reduce code duplication, improve maintainability, and ensure a consistent UI/UX for message display across different chat contexts.

### Key Changes

- **Removed** the inline `MessageCard` and `ConversationCard` components from `chat-room-section.tsx` and `private-chat-section.tsx`, respectively.
- **Introduced** a shared `MessageCard` component (imported from `../../message-card`) to handle the rendering of both text and image messages for both chat types.
- **Updated** the message mapping logic in both sections to pass the appropriate props to `MessageCard`, including sender status, message content, timestamps, images, and user names.
- **Type Adjustments** in `client/src/types/index.ts`:
  - Changed `ChatUserType.name` from `string | null` to `string` for consistency.
  - Updated `sent_at` in both `PrivateMessageType` and `MessageType` from `Date` to `string` to standardize timestamp handling.

### Why?

- **DRY Principle**: Removes duplicated message rendering logic, making future changes easier and less error-prone.
- **Consistency**: Ensures all messages (private and channel) are displayed with the same structure and styling.
- **Type Safety**: Updates to types ensure more predictable and robust data handling, especially for timestamps and user names.

### Impact

- No changes to backend or API contracts.
- No breaking changes to message data structure, but type updates may require minor adjustments elsewhere in the codebase if `sent_at` or `name` were previously handled as nullable or as `Date` objects.

---